### PR TITLE
Issue #36: Calibration Image Table Overlaping GUI

### DIFF
--- a/src/gui/panels/calibrator_panel.py
+++ b/src/gui/panels/calibrator_panel.py
@@ -151,6 +151,7 @@ class CalibratorPanel(BasePanel):
             sizer=control_sizer)
 
         self._image_table = CalibrationImageTable(parent=control_panel)
+        self._image_table.SetMaxSize((-1, self._image_table.GetSize().GetHeight()))
         control_sizer.Add(
             window=self._image_table,
             flags=wx.SizerFlags(0).Expand())
@@ -663,3 +664,7 @@ class CalibratorPanel(BasePanel):
                     self._result_state_selector.Enable(True)
                     self._result_state_selector.selector.SetStringSelection(result_metadata.state.name)
                     self._result_update_button.Enable(True)
+        self.Layout()
+        self.Refresh()
+        self.Update()
+


### PR DESCRIPTION
GUI visual overlap bug
![GUI_bug](https://github.com/PerkLab/MCSTrack/assets/67666861/c9d60190-245d-4e3c-9982-0218bf966c19)

GUI visual overlap fix
![GUI_fix1](https://github.com/PerkLab/MCSTrack/assets/67666861/5aedc740-803d-442c-8d9c-f08751772cee)
![GUI_fix2](https://github.com/PerkLab/MCSTrack/assets/67666861/1877d335-a276-4ca5-b95f-39311bb0bc42)

The visual bug was that if there are two many line of metadata, the table would expand downwards while the components below didn't have their position updated, creating a overlap. To fix this, I redrew the screen when the button was pressed: Layout, Refresh, Update. Took me all of Friday afternoon and Monday morning to figure this out and three lines was all it took to fix it.
