### PR TITLE
Make main_detector accessible on local network

### DIFF
--- a/src/main_detector.py
+++ b/src/main_detector.py
@@ -8,6 +8,7 @@ def main():
         app,
         reload=False,
         port=8001,
+        host="0.0.0.0",
         log_level=logging.INFO)
 
 


### PR DESCRIPTION
Added argument to uvicorn.run() to make main_detector accessible on the local network, as per [this documentation](https://www.uvicorn.org/settings/). 