### PR TITLE
FIX: specify numpy install version for OpenCV compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 fastapi==0.100.0
 fastapi-utils==0.2.1
 hjson
-numpy
-numpy-stl
+numpy==1.26.4
 opencv-contrib-python==4.5.5.64
 pydantic~=1.10.15
 PyOpenGL==3.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 fastapi==0.100.0
 fastapi-utils==0.2.1
 hjson
-numpy==1.26.4
+numpy~=1.26
+numpy-stl~=3.1
 opencv-contrib-python==4.5.5.64
 pydantic~=1.10.15
 PyOpenGL==3.1.7


### PR DESCRIPTION
Numpy 2.0 was released last week, which is incompatible with the required version of OpenCV--[read more here](https://github.com/opencv/opencv-python/issues/943). Added manual specification of numpy version to requirements to fix the problem. 