### PR TITLE
Add controller recording

### DIFF
--- a/src/controller/structures/detector_connection.py
+++ b/src/controller/structures/detector_connection.py
@@ -38,6 +38,7 @@ class DetectorConnection(Connection):
     current_resolution: ImageResolution | None
     current_intrinsic_parameters: IntrinsicParameters | None
     latest_frame: DetectorFrame | None
+    recording: list[DetectorFrame] | None
 
     def __init__(
         self,
@@ -48,6 +49,7 @@ class DetectorConnection(Connection):
         self.current_resolution = None
         self.current_intrinsic_parameters = None
         self.latest_frame = None
+        self.recording = []
 
     def create_deinitialization_request_series(self) -> MCTRequestSeries:
         return MCTRequestSeries(series=[DetectorStopRequest()])

--- a/src/controller/structures/pose_solver_connection.py
+++ b/src/controller/structures/pose_solver_connection.py
@@ -1,3 +1,4 @@
+from src.common.structures.pose_solver_frame import PoseSolverFrame
 from .mct_component_address import MCTComponentAddress
 from .connection import Connection
 from src.common.api import \
@@ -24,6 +25,7 @@ class PoseSolverConnection(Connection):
     target_poses: list[Pose]
     detector_timestamps: dict[str, datetime.datetime]  # access by detector_label
     poses_timestamp: datetime.datetime
+    recording: list[PoseSolverFrame] | None
 
     def __init__(
         self,
@@ -35,6 +37,7 @@ class PoseSolverConnection(Connection):
         self.target_poses = list()
         self.detector_timestamps = dict()
         self.poses_timestamp = datetime.datetime.min
+        self.recording = []
 
     def create_deinitialization_request_series(self) -> MCTRequestSeries:
         return MCTRequestSeries(series=[PoseSolverStopRequest()])


### PR DESCRIPTION
Added very rudimentary recording capabilities. Allows for specifying file save directory, and specifying whether detector, pose_solver, or both should be recorded. 

Current shortcomings:
1. When the JSON is written to the file it is all in one very long line. I'm not sure if this is an issue.
2. When tested with 5 minutes of recording, the detector_log is 3.2mb and the pose_solver_log is 7.4mb. This lags the GUI for around 5 seconds when writing the files. Might be faster on a more capable machine though (tested on RPi 5). 
3. No ability to specify _which_ detectors or pose solvers to record. Though maybe this isn't a needed functionality. 

I haven't tried replaying the data. I'd imagine that would require a good deal of work. I could be wrong though. 