### PR TITLE
ADD: Detector time sync functionality

### DIFF
--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -6,7 +6,11 @@ from .api import \
     MCTRequest, \
     MCTRequestSeries, \
     MCTResponse, \
-    MCTResponseSeries
+    MCTResponseSeries, \
+    TimestampGetRequest, \
+    TimestampGetResponse, \
+    TimeSyncStartRequest, \
+    TimeSyncStopRequest
 from .client_identifier_from_connection import client_identifier_from_connection
 from .get_kwarg import get_kwarg
 from .image_coding import ImageCoding

--- a/src/common/api/__init__.py
+++ b/src/common/api/__init__.py
@@ -6,3 +6,7 @@ from .mct_request import MCTRequest
 from .mct_request_series import MCTRequestSeries
 from .mct_response import MCTResponse
 from .mct_response_series import MCTResponseSeries
+from .timestamp_get_request import TimestampGetRequest
+from .timestamp_get_response import TimestampGetResponse
+from .time_sync_start_request import TimeSyncStartRequest
+from .time_sync_stop_request import TimeSyncStopRequest

--- a/src/common/api/time_sync_start_request.py
+++ b/src/common/api/time_sync_start_request.py
@@ -1,0 +1,10 @@
+from .mct_request import MCTRequest
+from pydantic import Field
+
+
+class TimeSyncStartRequest(MCTRequest):
+    @staticmethod
+    def parsable_type_identifier() -> str:
+        return "time_sync_start_request"
+
+    parsable_type: str = Field(default=parsable_type_identifier(), const=True)

--- a/src/common/api/time_sync_stop_request.py
+++ b/src/common/api/time_sync_stop_request.py
@@ -1,0 +1,10 @@
+from .mct_request import MCTRequest
+from pydantic import Field
+
+
+class TimeSyncStopRequest(MCTRequest):
+    @staticmethod
+    def parsable_type_identifier() -> str:
+        return "time_sync_start_request"
+
+    parsable_type: str = Field(default=parsable_type_identifier(), const=True)

--- a/src/common/api/timestamp_get_request.py
+++ b/src/common/api/timestamp_get_request.py
@@ -1,0 +1,11 @@
+from .mct_request import MCTRequest
+from pydantic import Field
+
+
+class TimestampGetRequest(MCTRequest):
+    @staticmethod
+    def parsable_type_identifier() -> str:
+        return "timestamp_get_request"
+
+    parsable_type: str = Field(default=parsable_type_identifier(), const=True)
+    requester_timestamp_utc_iso8601: str = Field()

--- a/src/common/api/timestamp_get_response.py
+++ b/src/common/api/timestamp_get_response.py
@@ -1,0 +1,18 @@
+import datetime
+from .mct_response import MCTResponse
+from src.common.structures.status_message import StatusMessage
+from pydantic import Field
+
+
+class TimestampGetResponse(MCTResponse):
+
+    @staticmethod
+    def parsable_type_identifier() -> str:
+        return "timestamp_get_response"
+
+    def timestamp_utc(self):
+        return datetime.datetime.fromisoformat(self.timestamp_utc_iso8601)
+
+    parsable_type: str = Field(default=parsable_type_identifier(), const=True)
+    requester_timestamp_utc_iso8601: str = Field()
+    responder_timestamp_utc_iso8601: str = Field()

--- a/src/controller/structures/detector_connection.py
+++ b/src/controller/structures/detector_connection.py
@@ -1,9 +1,7 @@
 from .mct_component_address import MCTComponentAddress
 from .connection import Connection
 from src.common.api import \
-    DequeueStatusMessagesResponse, \
     EmptyResponse, \
-    ErrorResponse, \
     MCTRequestSeries, \
     MCTResponse, \
     MCTResponseSeries
@@ -88,7 +86,7 @@ class DetectorConnection(Connection):
         return Connection.InitializationResult.SUCCESS
 
     def supported_response_types(self) -> list[type[MCTResponse]]:
-        return [
+        return super().supported_response_types() + [
             CalibrationCalculateResponse,
             CalibrationImageAddResponse,
             CalibrationImageGetResponse,
@@ -101,8 +99,5 @@ class DetectorConnection(Connection):
             CameraParametersGetResponse,
             CameraParametersSetResponse,
             CameraResolutionGetResponse,
-            DequeueStatusMessagesResponse,
             DetectorFrameGetResponse,
-            EmptyResponse,
-            ErrorResponse,
             MarkerParametersGetResponse]

--- a/src/controller/structures/pose_solver_connection.py
+++ b/src/controller/structures/pose_solver_connection.py
@@ -2,9 +2,7 @@ from src.common.structures.pose_solver_frame import PoseSolverFrame
 from .mct_component_address import MCTComponentAddress
 from .connection import Connection
 from src.common.api import \
-    DequeueStatusMessagesResponse, \
     EmptyResponse, \
-    ErrorResponse, \
     MCTRequestSeries, \
     MCTResponse, \
     MCTResponseSeries
@@ -76,8 +74,5 @@ class PoseSolverConnection(Connection):
         return Connection.InitializationResult.SUCCESS
 
     def supported_response_types(self) -> list[type[MCTResponse]]:
-        return [
-            DequeueStatusMessagesResponse,
-            EmptyResponse,
-            ErrorResponse,
+        return super().supported_response_types() + [
             PoseSolverGetPosesResponse]

--- a/src/detector/detector.py
+++ b/src/detector/detector.py
@@ -346,14 +346,15 @@ class Detector(MCTComponent):
         return return_value
 
     async def update(self):
-        if self._camera.get_status() == CameraStatus.RUNNING:
-            try:
-                self._camera.update()
-            except MCTDetectorRuntimeError as e:
-                self.add_status_message(severity="error", message=e.message)
-        if self._marker.get_status() == MarkerStatus.RUNNING and \
-           self._camera.get_changed_timestamp() > self._marker.get_changed_timestamp():
-            self._marker.update(self._camera.get_image())
-        self._frame_count += 1
-        if self._frame_count % 1000 == 0:
-            print(f"Update count: {self._frame_count}")
+        if not self._syncing_time:
+            if self._camera.get_status() == CameraStatus.RUNNING:
+                try:
+                    self._camera.update()
+                except MCTDetectorRuntimeError as e:
+                    self.add_status_message(severity="error", message=e.message)
+            if self._marker.get_status() == MarkerStatus.RUNNING and \
+            self._camera.get_changed_timestamp() > self._marker.get_changed_timestamp():
+                self._marker.update(self._camera.get_image())
+            self._frame_count += 1
+            if self._frame_count % 1000 == 0:
+                print(f"Update count: {self._frame_count}")

--- a/src/detector/detector_app.py
+++ b/src/detector/detector_app.py
@@ -1,7 +1,11 @@
 from src.common import \
     client_identifier_from_connection, \
     EmptyResponse, \
-    ErrorResponse
+    ErrorResponse, \
+    TimestampGetRequest, \
+    TimestampGetResponse, \
+    TimeSyncStartRequest, \
+    TimeSyncStopRequest
 from src.detector import \
     Detector, \
     DetectorConfiguration
@@ -89,12 +93,32 @@ def create_app() -> FastAPI:
         client_identifier: str = client_identifier_from_connection(connection=http_request)
         detector.detector_stop(client_identifier=client_identifier)
 
+    @detector_app.post("/detector/start_time_sync")
+    async def start_time_sync(
+        request: TimeSyncStartRequest
+    ) -> EmptyResponse:
+        return detector.time_sync_start(
+            request=request)
+    
+    @detector_app.post("/detector/stop_time_sync")
+    async def stop_time_sync(
+        request: TimeSyncStopRequest
+    ) -> EmptyResponse:
+        return detector.time_sync_stop(
+            request=request)
+
     @detector_app.post("/detector/get_frame")
     async def detector_get_frame(
         request: DetectorFrameGetRequest
     ) -> DetectorFrameGetResponse:
         return detector.detector_frame_get(
             request=request)
+    
+    @detector_app.get("/detector/get_timestamp")
+    async def get_timestamp(
+        request: TimestampGetRequest
+    ) -> TimestampGetResponse:
+        return detector.timestamp_get()
 
     @detector_app.get("/calibration/get_result_active")
     async def calibration_get_result_active() -> CalibrationResultGetActiveResponse:


### PR DESCRIPTION
Add capability to measure network latency between detector and controller for syncing the timestamps between pose solver and detector. Lays framework to address #81.

NOTE: this work does not actually _account_ for the delay within the pose solver, it just adds the functionality to _measure_ the latency. Future work should focus on accounting for this latency within the pose solver.  